### PR TITLE
setup.md: simplify instruction to install machine learning packages

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -82,7 +82,7 @@ If you run into any difficulties, please request help before the workshop begins
 Open a terminal and type the command (note that installing tensorflow causes keras to
 be installed too):
 ~~~
-$ conda install "tensorflow>=2.5" seaborn "scikit-learn>=0.22" pandas
+$ conda install tensorflow seaborn scikit-learn pandas
 ~~~
 {: .language-bash}
 


### PR DESCRIPTION
The installation command for versioned software 

    conda install "tensorflow>=2.5" seaborn "scikit-learn>=0.22" pandas

produces a conflict situation with the triplet **conda 4.11.0**, **anaconda-navigator 2.1.1**, **python 3.7.11**. 
A tell-tale excerpt of the stderr message is: 

     UnsatisfiableError: The following specifications were found
     to be incompatible with the existing python installation in your environment:
     Specifications:
     - pandas -> python[version='>=3.10,<3.11.0a0']

Conversely, a plain command 

    conda install tensorflow seaborn scikit-learn pandas
 
installed successfully **tensorflow-2.4.1**, **seaborn-0.11.2**, **scikit-learn-1.0.2**, **pandas-1.3.5**, **keras-preprocessing-1.1.2**. All versions are newer than the [minimum currently required by the course](https://carpentries-incubator.github.io/deep-learning-intro/01-introduction/index.html#installing-keras-and-other-dependencies) and although not than the version required for tensorflow.

Therefore, the explicit version requirements are probably unnecessary and counter-productive. It may be more important to update conda in the first place, for example with 

`conda update --all`

